### PR TITLE
Index HTTP requests when simulating effect

### DIFF
--- a/effects/Effects/CommonSimulator.elm
+++ b/effects/Effects/CommonSimulator.elm
@@ -13,8 +13,8 @@ import SimulatedEffect.Task as SimulatedTask
 import Time
 
 
-effectPerform : CommonEffect msg -> SimulatedEffect msg
-effectPerform effect =
+effectPerform : Int -> CommonEffect msg -> SimulatedEffect msg
+effectPerform index effect =
     case effect of
         Command _ ->
             SimulatedCmd.none
@@ -41,13 +41,13 @@ effectPerform effect =
             SimulatedCmd.none
 
         HttpRequest data ->
-            httpRequest data
+            httpRequest index data
 
         GraphqlHttpQuery data ->
-            graphqlHttpQuery data
+            graphqlHttpQuery index data
 
         GraphqlHttpMutation data ->
-            graphqlHttpMutation data
+            graphqlHttpMutation index data
 
 
 loop : msg -> SimulatedEffect msg
@@ -55,12 +55,12 @@ loop msg =
     SimulatedTask.perform identity <| SimulatedTask.succeed msg
 
 
-httpRequest : HttpRequestEffect msg -> SimulatedEffect msg
-httpRequest data =
+httpRequest : Int -> HttpRequestEffect msg -> SimulatedEffect msg
+httpRequest index data =
     ElmHttp.request
         { method = data.method
         , headers = []
-        , url = data.url
+        , url = data.url ++ "#i" ++ String.fromInt index
         , body = ElmHttp.emptyBody
         , timeout = data.timeout
         , tracker = data.tracker
@@ -68,15 +68,18 @@ httpRequest data =
         }
 
 
-graphqlHttpQuery : GraphqlRequestEffect RootQuery msg -> SimulatedEffect msg
-graphqlHttpQuery data =
-    ElmHttp.get { url = data.url, expect = graphqlExpect data }
+graphqlHttpQuery : Int -> GraphqlRequestEffect RootQuery msg -> SimulatedEffect msg
+graphqlHttpQuery index data =
+    ElmHttp.get
+        { url = data.url ++ "#i" ++ String.fromInt index
+        , expect = graphqlExpect data
+        }
 
 
-graphqlHttpMutation : GraphqlRequestEffect RootMutation msg -> SimulatedEffect msg
-graphqlHttpMutation data =
+graphqlHttpMutation : Int -> GraphqlRequestEffect RootMutation msg -> SimulatedEffect msg
+graphqlHttpMutation index data =
     ElmHttp.post
-        { url = data.url
+        { url = data.url ++ "#i" ++ String.fromInt index
         , body = ElmHttp.emptyBody
         , expect = graphqlExpect data
         }

--- a/effects/Effects/Simulator.elm
+++ b/effects/Effects/Simulator.elm
@@ -10,19 +10,22 @@ import SimulatedEffect.Cmd as SimulatedCmd
 
 simulator : Effects Msg -> SimulatedEffect Msg
 simulator effects =
-    Effects.apply effectsApplier SimulatedCmd.none effects
+    effects
+        |> Effects.apply effectsApplier
+            ( 0, SimulatedCmd.none )
+        |> Tuple.second
 
 
-effectsApplier : Effects.Effect Msg -> SimulatedEffect Msg -> SimulatedEffect Msg
-effectsApplier effect accumulator =
-    SimulatedCmd.batch [ effectPerform effect, accumulator ]
+effectsApplier : Effects.Effect Msg -> ( Int, SimulatedEffect Msg ) -> ( Int, SimulatedEffect Msg )
+effectsApplier effect ( i, accumulator ) =
+    ( i + 1, SimulatedCmd.batch [ effectPerform i effect, accumulator ] )
 
 
-effectPerform : Effect Msg -> SimulatedEffect Msg
-effectPerform effect =
+effectPerform : Int -> Effect Msg -> SimulatedEffect Msg
+effectPerform index effect =
     case effect of
         LocalEffect subEffect ->
             Local.effectPerform subEffect
 
         CommonEffect subEffect ->
-            Common.effectPerform subEffect
+            Common.effectPerform index subEffect


### PR DESCRIPTION
An XGH solution to bypass this issue: https://github.com/avh4/elm-program-test/issues/77

I don't like it, so if you guys think about anything else that would work, please let me know!

We're hitting this in LMO, because the FleetAssigment page requests both the list of orders and the list of drivers.