### PR TITLE
Move code's version to appConfig

### DIFF
--- a/elm/Paack/Rollbar/Performer.elm
+++ b/elm/Paack/Rollbar/Performer.elm
@@ -42,17 +42,20 @@ performEffectWithModel :
     (RollbarResult -> msg)
     ->
         { a
-            | appConfig : { b | environment : Environment }
+            | appConfig :
+                { b
+                    | environment : Environment
+                    , version : String
+                }
             , url : Url
             , rollbarToken : MaybeToken
-            , codeVersion : String
         }
     -> Effect
     -> Cmd msg
-performEffectWithModel feedbackMsg { appConfig, codeVersion, rollbarToken, url } effect =
+performEffectWithModel feedbackMsg { appConfig, rollbarToken, url } effect =
     performEffect feedbackMsg
         appConfig.environment
-        codeVersion
+        appConfig.version
         rollbarToken
         url
         effect

--- a/example/src/Main/Model.elm
+++ b/example/src/Main/Model.elm
@@ -12,9 +12,8 @@ import Url exposing (Url)
 
 
 type alias Model =
-    { appConfig : { environment : Environment }
+    { appConfig : { environment : Environment, version : String }
     , auth : Auth.Model
-    , codeVersion : String
     , url : Url
     , user : Maybe User
     , rollbarToken : Rollbar.MaybeToken
@@ -41,9 +40,11 @@ init flags url _ =
         ( auth, authEffects ) =
             Auth.init authConfig
     in
-    ( { appConfig = { environment = Environment.Development }
+    ( { appConfig =
+            { environment = Environment.Development
+            , version = " v0.0.0-1-g99c0ff3"
+            }
       , auth = auth
-      , codeVersion = "git"
       , url = url
       , user = Nothing
       , rollbarToken = Rollbar.initToken flags.rollbarToken


### PR DESCRIPTION
#### :thinking: What?

In `Rollbar.Performer.performEffectWithModel`, moves the `codeVersion` to `appConfig.version`.

#### :man_shrugging: Why?

It's interesting sometimes to show the app's version in View.

#### :pushpin: Jira Issue

Not tracked

#### :no_good: Blocked by

Not blocked

#### :clipboard: Pending

Nothing.