### PR TITLE
Fix Auth's treatable errors

### DIFF
--- a/auth0/auth.ts
+++ b/auth0/auth.ts
@@ -14,7 +14,11 @@ class ElmTreatableError extends Error {
 
   constructor(tag: string, message: string) {
     super(message);
+    this.name = 'ElmTreatableError';
     this.tag = tag;
+
+    // https://github.com/microsoft/TypeScript/wiki/Breaking-Changes#extending-built-ins-like-error-array-and-map-may-no-longer-work
+    Object.setPrototypeOf(this, ElmTreatableError.prototype);
   }
 
   public toJSON(): AuthError {


### PR DESCRIPTION
#### :thinking: What?

* Use `setPrototypeOf` in `ElmTreatableError`

#### :man_shrugging: Why?

* `checkSession` was not returning login failures, [because of this bug](https://github.com/microsoft/TypeScript/wiki/Breaking-Changes#extending-built-ins-like-error-array-and-map-may-no-longer-work).

#### :pushpin: Jira Issue

Not tracked

#### :no_good: Blocked by

Not blocked

#### :clipboard: Pending

Nothing.