### PR TITLE
WS-556 | Fix existing bug in `UI.Return.withEffect`

### DIFF
--- a/elm/Paack/List.elm
+++ b/elm/Paack/List.elm
@@ -1,7 +1,7 @@
 module Paack.List exposing (..)
 
-import UUID exposing (UUID)
 import Set
+import UUID exposing (UUID)
 
 
 unique : List comparable -> List comparable

--- a/elm/Paack/Return.elm
+++ b/elm/Paack/Return.elm
@@ -66,8 +66,8 @@ mapEffect applier ( model, effect ) =
 
 
 withEffect : Effects msg -> Return msg a -> Return msg a
-withEffect effect =
-    mapEffect (always effect)
+withEffect effect_ ( model, effect ) =
+    ( model, Effects.batch [ effect, effect_ ] )
 
 
 withEffects : List (Effects msg) -> Return msg a -> Return msg a

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@PaackEng/frontend-elm-kit",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "",
   "private": false,
   "files": [


### PR DESCRIPTION
#### :thinking: What?

Fixes `UI.Return.withEffect` function, as it is this is causing [WS-556](https://paacklogistics.atlassian.net/browse/WS-556) in `wms-web`

#### :man_shrugging: Why?

`UI.Return.withEffect` is discarding the received effect.

#### :pushpin: Jira Issue

 [WS-556](https://paacklogistics.atlassian.net/browse/WS-556)

#### :no_good: Blocked by

Not blocked

#### :clipboard: Pending

- [x] Feed the trolls.

### :fire: Extra

Good thing no one else is using this function
