### PR TITLE
LMO-2043 | Add profiling capabilities

### DIFF
--- a/elm/Paack/Profiler.elm
+++ b/elm/Paack/Profiler.elm
@@ -1,0 +1,135 @@
+module Paack.Profiler exposing (Program, browserApplication)
+
+import Browser exposing (UrlRequest)
+import Html exposing (Html, canvas, div)
+import Html.Attributes exposing (attribute, id)
+import Html.Lazy exposing (lazy)
+import Main.Model exposing (Flags, Model)
+import Main.Msg exposing (Msg)
+import Main.Pages exposing (PageModel)
+import Paack.Effects.MainHelper exposing (PerformerModel, performedInit, performedUpdate)
+import UI.Document as UI exposing (Document)
+import UI.RenderConfig exposing (RenderConfig)
+import Url exposing (Url)
+
+
+type alias Program =
+    Platform.Program Flags ( Int, PerformerModel ) Msg
+
+
+type alias ProgramData =
+    { view : Model -> Document PageModel Msg
+    , subscriptions : Model -> Sub Msg
+    , onUrlRequest : UrlRequest -> Msg
+    , onUrlChange : Url -> Msg
+    , getRenderConfig : Model -> RenderConfig
+    , getPage : Model -> PageModel
+    }
+
+
+start : String
+start =
+    "profile://start/"
+
+
+end : String
+end =
+    "profile://end/"
+
+
+browserApplication : ProgramData -> Program
+browserApplication data =
+    Browser.application
+        { init =
+            \flags url key ->
+                let
+                    startTag =
+                        start ++ "code/0"
+
+                    endTag =
+                        end ++ "code/0"
+                in
+                key
+                    |> escape startTag ()
+                    |> performedInit flags url
+                    |> escape endTag flags
+                    |> Tuple.mapFirst (Tuple.pair 0)
+        , view =
+            \( counter, { appModel } ) ->
+                let
+                    counterStr =
+                        String.fromInt counter
+
+                    startTag =
+                        start ++ "view/" ++ counterStr
+
+                    endTag =
+                        end ++ "view/" ++ counterStr
+                in
+                appModel
+                    |> escape startTag ()
+                    |> data.view
+                    |> UI.withExtraHtml charts
+                    |> UI.toBrowserDocument
+                        (data.getRenderConfig appModel)
+                        (data.getPage appModel)
+                    |> escape endTag ()
+        , update =
+            \msg ( counter, model ) ->
+                let
+                    nextCounter =
+                        counter + 1
+
+                    counterStr =
+                        String.fromInt nextCounter
+
+                    startTag =
+                        start ++ "code/" ++ counterStr
+
+                    endTag =
+                        end ++ "code/" ++ counterStr
+                in
+                model
+                    |> escape startTag ()
+                    |> performedUpdate msg
+                    |> escape endTag msg
+                    |> Tuple.mapFirst (Tuple.pair nextCounter)
+        , onUrlRequest = data.onUrlRequest
+        , onUrlChange = data.onUrlChange
+        , subscriptions = Tuple.second >> .appModel >> data.subscriptions
+        }
+
+
+escape : String -> a -> b -> b
+escape tag data return =
+    let
+        _ =
+            Debug.log tag data
+    in
+    return
+
+
+immortal : ()
+immortal =
+    ()
+
+
+charts : List (Html msg)
+charts =
+    [ lazy
+        (\_ ->
+            div [ attribute "style" "position: fixed; opacity: 0.9; top: 50vh; width: 20vw; left: 0; right: auto; z-index: 99999;" ]
+                [ canvas [ id "code-chart" ]
+                    []
+                ]
+        )
+        immortal
+    , lazy
+        (\_ ->
+            div [ attribute "style" "position: fixed; opacity: 0.9; top: 50vh; width: 20vw; left: auto; right: 0; z-index: 99999;" ]
+                [ canvas [ id "view-chart" ]
+                    []
+                ]
+        )
+        immortal
+    ]

--- a/elm/Paack/Profiler.elm
+++ b/elm/Paack/Profiler.elm
@@ -7,8 +7,10 @@ import Html.Lazy exposing (lazy)
 import Main.Model exposing (Flags, Model)
 import Main.Msg exposing (Msg)
 import Main.Pages exposing (PageModel)
+import Main.Subscriptions exposing (subscriptions)
+import Main.View exposing (view)
 import Paack.Effects.MainHelper exposing (PerformerModel, performedInit, performedUpdate)
-import UI.Document as UI exposing (Document)
+import UI.Document as UI
 import UI.RenderConfig exposing (RenderConfig)
 import Url exposing (Url)
 
@@ -18,9 +20,7 @@ type alias Program =
 
 
 type alias ProgramData =
-    { view : Model -> Document PageModel Msg
-    , subscriptions : Model -> Sub Msg
-    , onUrlRequest : UrlRequest -> Msg
+    { onUrlRequest : UrlRequest -> Msg
     , onUrlChange : Url -> Msg
     , getRenderConfig : Model -> RenderConfig
     , getPage : Model -> PageModel
@@ -68,7 +68,7 @@ browserApplication data =
                 in
                 appModel
                     |> escape startTag ()
-                    |> data.view
+                    |> view
                     |> UI.withExtraHtml charts
                     |> UI.toBrowserDocument
                         (data.getRenderConfig appModel)
@@ -96,7 +96,7 @@ browserApplication data =
                     |> Tuple.mapFirst (Tuple.pair nextCounter)
         , onUrlRequest = data.onUrlRequest
         , onUrlChange = data.onUrlChange
-        , subscriptions = Tuple.second >> .appModel >> data.subscriptions
+        , subscriptions = Tuple.second >> .appModel >> subscriptions
         }
 
 

--- a/elm/Paack/Program.elm
+++ b/elm/Paack/Program.elm
@@ -1,22 +1,12 @@
 module Paack.Program exposing (Program, browserApplication)
 
 import Browser exposing (UrlRequest)
-import Browser.Navigation as Nav exposing (Key)
-import Effects.LocalPerformer as LocalPerformer
-import Html exposing (Html, canvas, div)
-import Html.Attributes exposing (attribute, id)
-import Html.Lazy as Lazy exposing (lazy)
-import Main.Model as Model exposing (Flags, Model)
+import Main.Model exposing (Flags, Model)
 import Main.Msg exposing (Msg)
 import Main.Pages exposing (PageModel)
-import Main.Update exposing (update)
-import Paack.Effects as Effects
-import Paack.Effects.CommonPerformer as CommonPerformer
 import Paack.Effects.MainHelper exposing (PerformerModel, performedInit, performedUpdate)
-import Random
 import UI.Document as UI exposing (Document)
 import UI.RenderConfig exposing (RenderConfig)
-import UUID exposing (Seeds)
 import Url exposing (Url)
 
 

--- a/elm/Paack/Program.elm
+++ b/elm/Paack/Program.elm
@@ -4,8 +4,10 @@ import Browser exposing (UrlRequest)
 import Main.Model exposing (Flags, Model)
 import Main.Msg exposing (Msg)
 import Main.Pages exposing (PageModel)
+import Main.Subscriptions exposing (subscriptions)
+import Main.View exposing (view)
 import Paack.Effects.MainHelper exposing (PerformerModel, performedInit, performedUpdate)
-import UI.Document as UI exposing (Document)
+import UI.Document as UI
 import UI.RenderConfig exposing (RenderConfig)
 import Url exposing (Url)
 
@@ -15,9 +17,7 @@ type alias Program =
 
 
 type alias ProgramData =
-    { view : Model -> Document PageModel Msg
-    , subscriptions : Model -> Sub Msg
-    , onUrlRequest : UrlRequest -> Msg
+    { onUrlRequest : UrlRequest -> Msg
     , onUrlChange : Url -> Msg
     , getRenderConfig : Model -> RenderConfig
     , getPage : Model -> PageModel
@@ -30,12 +30,12 @@ browserApplication data =
         { init = performedInit
         , view =
             \{ appModel } ->
-                data.view appModel
+                view appModel
                     |> UI.toBrowserDocument
                         (data.getRenderConfig appModel)
                         (data.getPage appModel)
         , update = performedUpdate
         , onUrlRequest = data.onUrlRequest
         , onUrlChange = data.onUrlChange
-        , subscriptions = .appModel >> data.subscriptions
+        , subscriptions = .appModel >> subscriptions
         }

--- a/elm/Paack/Program.elm
+++ b/elm/Paack/Program.elm
@@ -1,0 +1,51 @@
+module Paack.Program exposing (Program, browserApplication)
+
+import Browser exposing (UrlRequest)
+import Browser.Navigation as Nav exposing (Key)
+import Effects.LocalPerformer as LocalPerformer
+import Html exposing (Html, canvas, div)
+import Html.Attributes exposing (attribute, id)
+import Html.Lazy as Lazy exposing (lazy)
+import Main.Model as Model exposing (Flags, Model)
+import Main.Msg exposing (Msg)
+import Main.Pages exposing (PageModel)
+import Main.Update exposing (update)
+import Paack.Effects as Effects
+import Paack.Effects.CommonPerformer as CommonPerformer
+import Paack.Effects.MainHelper exposing (PerformerModel, performedInit, performedUpdate)
+import Random
+import UI.Document as UI exposing (Document)
+import UI.RenderConfig exposing (RenderConfig)
+import UUID exposing (Seeds)
+import Url exposing (Url)
+
+
+type alias Program =
+    Platform.Program Flags PerformerModel Msg
+
+
+type alias ProgramData =
+    { view : Model -> Document PageModel Msg
+    , subscriptions : Model -> Sub Msg
+    , onUrlRequest : UrlRequest -> Msg
+    , onUrlChange : Url -> Msg
+    , getRenderConfig : Model -> RenderConfig
+    , getPage : Model -> PageModel
+    }
+
+
+browserApplication : ProgramData -> Program
+browserApplication data =
+    Browser.application
+        { init = performedInit
+        , view =
+            \{ appModel } ->
+                data.view appModel
+                    |> UI.toBrowserDocument
+                        (data.getRenderConfig appModel)
+                        (data.getPage appModel)
+        , update = performedUpdate
+        , onUrlRequest = data.onUrlRequest
+        , onUrlChange = data.onUrlChange
+        , subscriptions = .appModel >> data.subscriptions
+        }

--- a/elm/Paack/ProgramTest.elm
+++ b/elm/Paack/ProgramTest.elm
@@ -1,0 +1,41 @@
+module Paack.ProgramTest exposing (ProgramDefinition, createApplication)
+
+import Browser exposing (UrlRequest)
+import Main.Model as Model exposing (Flags, Model)
+import Main.Msg exposing (Msg)
+import Main.Pages exposing (PageModel)
+import Main.Update exposing (update)
+import Main.View exposing (view)
+import Paack.Effects exposing (Effects)
+import ProgramTest
+import UI.Document as UI
+import UI.RenderConfig exposing (RenderConfig)
+import Url exposing (Url)
+
+
+type alias ProgramDefinition =
+    ProgramTest.ProgramDefinition Flags Model Msg (Effects Msg)
+
+
+type alias ProgramData =
+    { onUrlRequest : UrlRequest -> Msg
+    , onUrlChange : Url -> Msg
+    , getRenderConfig : Model -> RenderConfig
+    , getPage : Model -> PageModel
+    }
+
+
+createApplication : ProgramData -> ProgramDefinition
+createApplication data =
+    ProgramTest.createApplication
+        { init = Model.init
+        , view =
+            \model ->
+                view model
+                    |> UI.toBrowserDocument
+                        (data.getRenderConfig model)
+                        (data.getPage model)
+        , update = update
+        , onUrlRequest = data.onUrlRequest
+        , onUrlChange = data.onUrlChange
+        }

--- a/example/elm.json
+++ b/example/elm.json
@@ -10,7 +10,7 @@
             "NoRedInk/elm-json-decode-pipeline": "1.0.1",
             "NoRedInk/elm-rollbar": "2.0.1",
             "PaackEng/paack-remotedata": "1.1.0",
-            "PaackEng/paack-ui": "7.19.3",
+            "PaackEng/paack-ui": "7.21.0",
             "TSFoster/elm-uuid": "4.1.0",
             "avh4/elm-fifo": "1.0.4",
             "dillonkearns/elm-graphql": "5.0.9",
@@ -22,6 +22,7 @@
             "elm/random": "1.0.0",
             "elm/time": "1.0.0",
             "elm/url": "1.0.0",
+            "mdgriffith/elm-ui": "1.1.8",
             "rtfeldman/elm-iso8601-date-strings": "1.1.4"
         },
         "indirect": {
@@ -41,7 +42,6 @@
             "elm-community/list-extra": "8.5.2",
             "j-maas/elm-ordered-containers": "1.0.0",
             "lukewestby/elm-string-interpolate": "1.0.4",
-            "mdgriffith/elm-ui": "1.1.8",
             "rtfeldman/elm-hex": "1.0.0",
             "zwilias/elm-utf-tools": "2.0.1"
         }

--- a/example/review/src/ReviewConfig.elm
+++ b/example/review/src/ReviewConfig.elm
@@ -23,7 +23,7 @@ import NoUnused.Dependencies
 import NoUnused.Parameters
 import NoUnused.Patterns
 import NoUnused.Variables
-import Review.Rule exposing (Rule, ignoreErrorsForDirectories)
+import Review.Rule as Rule exposing (Rule)
 import Simplify
 
 
@@ -32,7 +32,9 @@ import Simplify
 config : List Rule
 config =
     [ NoBooleanCase.rule
-    , NoDebug.Log.rule
+    , Rule.ignoreErrorsForFiles
+        [ "../elm/Paack/Profiler.elm" ]
+        NoDebug.Log.rule
     , NoDebug.TodoOrToString.rule
     , NoDeprecated.rule NoDeprecated.defaults
     , NoInvalidRGBValues.rule

--- a/example/src/Main.elm
+++ b/example/src/Main.elm
@@ -1,20 +1,18 @@
 module Main exposing (main)
 
-import Browser
-import Main.Model exposing (Flags)
-import Main.Msg as Msg exposing (Msg)
+import Main.Msg as Msg
 import Main.Subscriptions as Subscriptions
 import Main.View as View
-import Paack.Effects.MainHelper exposing (PerformerModel, performedInit, performedUpdate)
+import Paack.Program as Paack
 
 
-main : Platform.Program Flags PerformerModel Msg
+main : Paack.Program
 main =
-    Browser.application
-        { init = performedInit
-        , view = .appModel >> View.view
-        , update = performedUpdate
+    Paack.browserApplication
+        { view = View.view
         , onUrlRequest = Msg.LinkClicked
         , onUrlChange = Msg.UrlChanged
-        , subscriptions = .appModel >> Subscriptions.subscriptions
+        , subscriptions = Subscriptions.subscriptions
+        , getRenderConfig = .appConfig >> .renderConfig
+        , getPage = .page
         }

--- a/example/src/Main.elm
+++ b/example/src/Main.elm
@@ -1,18 +1,14 @@
 module Main exposing (main)
 
 import Main.Msg as Msg
-import Main.Subscriptions as Subscriptions
-import Main.View as View
 import Paack.Program as Paack
 
 
 main : Paack.Program
 main =
     Paack.browserApplication
-        { view = View.view
-        , onUrlRequest = Msg.LinkClicked
+        { onUrlRequest = Msg.LinkClicked
         , onUrlChange = Msg.UrlChanged
-        , subscriptions = Subscriptions.subscriptions
         , getRenderConfig = .appConfig >> .renderConfig
         , getPage = .page
         }

--- a/example/src/Main/Model.elm
+++ b/example/src/Main/Model.elm
@@ -3,6 +3,7 @@ module Main.Model exposing (Flags, Model, authConfig, init)
 import Data.Environment as Environment exposing (Environment)
 import Effects.Local exposing (LocalEffect(..))
 import Main.Msg as Msg exposing (Msg)
+import Main.Pages as Pages exposing (PageModel)
 import Paack.Auth.Main as Auth
 import Paack.Auth.User exposing (User)
 import Paack.Effects as Effects exposing (Effects, fromLocal)
@@ -10,22 +11,28 @@ import Paack.Mixpanel as Mixpanel exposing (Mixpanel)
 import Paack.Rollbar as Rollbar
 import Paack.Rollbar.Dispatch as Rollbar
 import Random
+import UI.Document as UI
+import UI.RenderConfig as RenderConfig exposing (RenderConfig)
 import UUID exposing (Seeds)
 import Url exposing (Url)
 
 
 type alias Model =
-    { appConfig : { environment : Environment, version : String }
+    { appConfig : { environment : Environment, version : String, renderConfig : RenderConfig }
     , auth : Auth.Model
+    , ui : UI.Model
     , url : Url
     , user : Maybe User
     , rollbarToken : Rollbar.MaybeToken
     , mixpanel : Mixpanel
+    , page : PageModel
     }
 
 
 type alias Flags =
-    { randomSeed1 : Int
+    { innerWidth : Int
+    , innerHeight : Int
+    , randomSeed1 : Int
     , randomSeed2 : Int
     , randomSeed3 : Int
     , randomSeed4 : Int
@@ -63,16 +70,24 @@ init flags url _ =
                 , identifyEffect = \_ _ -> Effects.none
                 , session = Nothing
                 }
+
+        renderConfig =
+            RenderConfig.init
+                { width = flags.innerWidth, height = flags.innerHeight }
+                RenderConfig.localeEnglish
     in
     ( { appConfig =
             { environment = Environment.Development
             , version = " v0.0.0-1-g99c0ff3"
+            , renderConfig = renderConfig
             }
       , auth = auth
+      , ui = UI.modelInit renderConfig
       , url = url
       , user = Nothing
       , rollbarToken = Rollbar.initToken flags.rollbarToken
       , mixpanel = mixpanel
+      , page = Pages.Home
       }
     , Effects.batch
         [ fromLocal <| AuthEffect authEffects

--- a/example/src/Main/Msg.elm
+++ b/example/src/Main/Msg.elm
@@ -3,11 +3,13 @@ module Main.Msg exposing (Msg(..))
 import Browser
 import Paack.Auth.Main as Auth
 import Paack.Rollbar.Effect exposing (RollbarResult)
+import UI.Document as UI
 import Url
 
 
 type Msg
     = ForAuth Auth.Msg
+    | ForUI UI.Msg
     | LinkClicked Browser.UrlRequest
     | RollbarFeedback RollbarResult
     | UrlChanged Url.Url

--- a/example/src/Main/Pages.elm
+++ b/example/src/Main/Pages.elm
@@ -1,0 +1,5 @@
+module Main.Pages exposing (PageModel(..))
+
+
+type PageModel
+    = Home

--- a/example/src/Main/Update.elm
+++ b/example/src/Main/Update.elm
@@ -6,6 +6,7 @@ import Main.Msg exposing (Msg(..))
 import Paack.Auth.Main as Auth
 import Paack.Effects as Effects
 import Paack.Return as R exposing (Return)
+import UI.Document as UI
 
 
 update : Msg -> Model -> Return Msg Model
@@ -13,6 +14,9 @@ update msg model =
     case msg of
         ForAuth subMsg ->
             forAuth subMsg model
+
+        ForUI subMsg ->
+            forUI subMsg model
 
         LinkClicked _ ->
             R.singleton model
@@ -35,3 +39,14 @@ forAuth subMsg model =
     in
     R.singleton { model | auth = subModel, user = Auth.getUser subModel }
         |> R.withEffect (Effects.fromLocal <| AuthEffect effects)
+
+
+forUI : UI.Msg -> Model -> Return Msg Model
+forUI subMsg model =
+    let
+        ( newState, navEffects ) =
+            UI.modelUpdateWithoutPerform subMsg model.ui
+    in
+    ( { model | ui = newState }
+    , Effects.map ForUI <| Effects.paackUI (always Effects.none) navEffects
+    )

--- a/example/src/Main/View.elm
+++ b/example/src/Main/View.elm
@@ -1,19 +1,37 @@
 module Main.View exposing (view)
 
 import Browser
-import Html exposing (..)
+import Element exposing (text)
 import Main.Model exposing (Model)
+import Main.Msg as Msg exposing (Msg)
+import Main.Pages exposing (PageModel)
 import Paack.Auth.User as User
+import UI.Document as UI
 
 
-view : Model -> Browser.Document msg
+view : Model -> UI.Document PageModel Msg
 view model =
-    { title = "frontend-elm-kit example"
-    , body =
-        case model.user of
-            Just user ->
-                [ text "User name: ", User.getData user |> .name |> text ]
+    UI.document
+        Msg.ForUI
+        model.ui
+        (pageContainer model)
 
-            Nothing ->
-                [ text "Authenticating..." ]
-    }
+
+pageContainer : Model -> PageModel -> UI.Page Msg
+pageContainer model _ =
+    let
+        title =
+            "frontend-elm-kit example"
+
+        body =
+            case model.user of
+                Just user ->
+                    [ text "User name: ", User.getData user |> .name |> text ]
+
+                Nothing ->
+                    [ text "Authenticating..." ]
+    in
+    body
+        |> Element.column []
+        |> UI.bodySingle
+        |> UI.page title

--- a/example/src/Main/View.elm
+++ b/example/src/Main/View.elm
@@ -1,6 +1,5 @@
 module Main.View exposing (view)
 
-import Browser
 import Element exposing (text)
 import Main.Model exposing (Model)
 import Main.Msg as Msg exposing (Msg)

--- a/example/tests/Example.elm
+++ b/example/tests/Example.elm
@@ -2,15 +2,14 @@ module Example exposing (authFlow)
 
 import Iso8601
 import Json.Encode as Encode
-import Main.Model as Model exposing (Flags, Model, authConfig)
+import Main.Model exposing (Flags, Model, authConfig)
 import Main.Msg as Msg exposing (Msg)
-import Main.Update exposing (update)
-import Main.View exposing (view)
 import Paack.Auth.Main as Auth
 import Paack.Auth.User as User
 import Paack.Effects exposing (Effects)
 import Paack.Effects.Simulator exposing (simulator)
-import ProgramTest exposing (ProgramDefinition, ProgramTest, expectViewHas)
+import Paack.ProgramTest as Paack exposing (ProgramDefinition)
+import ProgramTest exposing (ProgramTest, expectViewHas)
 import SimulatedEffect.Ports
 import Test exposing (..)
 import Test.Html.Selector exposing (text)
@@ -28,7 +27,9 @@ start =
 
 mockFlags : Flags
 mockFlags =
-    { randomSeed1 = -1
+    { innerWidth = 1920
+    , innerHeight = 1080
+    , randomSeed1 = -1
     , randomSeed2 = -1
     , randomSeed3 = -1
     , randomSeed4 = -1
@@ -38,14 +39,13 @@ mockFlags =
     }
 
 
-programDefinition : ProgramDefinition Flags Model Msg (Effects Msg)
+programDefinition : ProgramDefinition
 programDefinition =
-    ProgramTest.createApplication
-        { init = Model.init
-        , view = view
-        , update = update
-        , onUrlRequest = Msg.LinkClicked
+    Paack.createApplication
+        { onUrlRequest = Msg.LinkClicked
         , onUrlChange = Msg.UrlChanged
+        , getRenderConfig = .appConfig >> .renderConfig
+        , getPage = .page
         }
 
 

--- a/example/web/ts/index.ts
+++ b/example/web/ts/index.ts
@@ -9,6 +9,8 @@ const app = Elm.Main.init({
   node: document.getElementById('main'),
   flags: {
     gitDescribe,
+    innerWidth: window.innerWidth,
+    innerHeight: window.innerHeight,
     randomSeed1: seeds[0],
     randomSeed2: seeds[1],
     randomSeed3: seeds[2],

--- a/package.json
+++ b/package.json
@@ -39,7 +39,9 @@
   },
   "peerDependencies": {
     "@auth0/auth0-spa-js": "^1.20.1",
+    "@types/chart.js": "^2.9.36",
     "@types/elm": "^0.19.1",
+    "chart.js": "^3.7.1",
     "elm": "^0.19.1-5",
     "elm-review": "^2.7.1",
     "elm-test": "^0.19.1-revision7",
@@ -47,9 +49,11 @@
   },
   "devDependencies": {
     "@auth0/auth0-spa-js": "^1.20.1",
+    "@types/chart.js": "^2.9.36",
     "@types/elm": "^0.19.1",
     "@typescript-eslint/eslint-plugin": "^5.17.0",
     "@typescript-eslint/parser": "^5.17.0",
+    "chart.js": "^3.7.1",
     "eslint": "^8.12.0",
     "prettier": "^2.6.1",
     "typescript": "^4.6.3"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@PaackEng/frontend-elm-kit",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "description": "",
   "private": false,
   "files": [

--- a/profiler/index.ts
+++ b/profiler/index.ts
@@ -1,4 +1,11 @@
-import { Chart } from 'chart.js';
+import {
+  Chart,
+  ScatterController,
+  LinearScale,
+  PointElement,
+  LineElement,
+} from 'chart.js';
+Chart.register(ScatterController, LinearScale, PointElement, LineElement);
 
 type Benchmark = { topic: string; index: number; duration: number };
 type Benchmarks = Benchmark[];

--- a/profiler/index.ts
+++ b/profiler/index.ts
@@ -4,8 +4,15 @@ import {
   LinearScale,
   PointElement,
   LineElement,
+  Legend,
 } from 'chart.js';
-Chart.register(ScatterController, LinearScale, PointElement, LineElement);
+Chart.register(
+  ScatterController,
+  LinearScale,
+  PointElement,
+  LineElement,
+  Legend,
+);
 
 type Benchmark = { topic: string; index: number; duration: number };
 type Benchmarks = Benchmark[];

--- a/profiler/index.ts
+++ b/profiler/index.ts
@@ -1,0 +1,131 @@
+import { Chart } from 'chart.js';
+
+type Benchmark = { topic: string; index: number; duration: number };
+type Benchmarks = Benchmark[];
+type Profiling = { id: string; samples: Benchmarks[] };
+
+const profileApp = (env: {
+  profilingId: string;
+  profilingSamples: number;
+  profilingMessages: number;
+}) => {
+  const originalConsoleLog = window.console.log;
+
+  const benchmarkRegex = /^profile:\/\/([^\/]+)\/([^\/]+)\/([^:]+): (.*)$/;
+
+  const benchmarksStart: Record<string, number> = {};
+  const benchmarks: Benchmarks = [];
+  var codeChart: Chart | null = null;
+  var viewChart: Chart | null = null;
+
+  var autoProfiling: Profiling | null = null;
+  if (env.profilingId !== '') {
+    try {
+      autoProfiling = JSON.parse(localStorage.profiling);
+    } catch (_) {
+      autoProfiling = null;
+    }
+    if (autoProfiling === null || autoProfiling.id !== env.profilingId) {
+      alert('Started profiling');
+      autoProfiling = { id: env.profilingId, samples: [] };
+    }
+    if (autoProfiling.samples.length >= env.profilingSamples) {
+      autoProfiling = null;
+    }
+  }
+
+  const chartOptions = {
+    responsive: true,
+    showLine: true,
+  };
+
+  function updateCodeGraph(newData: { x: number; y: number }) {
+    if (autoProfiling !== null) return null;
+    if (codeChart === null) {
+      const node = document.getElementById('code-chart');
+      if (!(node instanceof HTMLCanvasElement)) return;
+      codeChart = new Chart(node, {
+        type: 'scatter',
+        data: {
+          datasets: [
+            {
+              label: 'Code timegraph',
+              data: [newData],
+            },
+          ],
+        },
+        options: chartOptions,
+      });
+    } else {
+      codeChart.data.datasets[0].data.push(newData);
+      codeChart.update();
+    }
+  }
+
+  function updateViewGraph(newData: { x: number; y: number }) {
+    if (autoProfiling !== null) return null;
+    if (viewChart === null) {
+      const node = document.getElementById('view-chart');
+      if (!(node instanceof HTMLCanvasElement)) return;
+      viewChart = new Chart(node, {
+        type: 'scatter',
+        data: {
+          datasets: [
+            {
+              label: 'View timegraph',
+              data: [newData],
+            },
+          ],
+        },
+        options: chartOptions,
+      });
+    } else {
+      viewChart.data.datasets[0].data.push(newData);
+      viewChart.update();
+    }
+  }
+
+  window.console.log = function (message?: any, ...optionalParams: any[]) {
+    const benchmarkMatch = message.toString().match(benchmarkRegex);
+    if (benchmarkMatch !== null) {
+      const now = new Date().getTime();
+      const action = benchmarkMatch[1];
+      const topic = benchmarkMatch[2];
+      const index = parseInt(benchmarkMatch[3]);
+
+      if (action === 'start') {
+        benchmarksStart[topic] = now;
+      } else if (action === 'end') {
+        const duration = now - benchmarksStart[topic];
+        benchmarks.push({
+          topic,
+          index,
+          duration,
+        });
+
+        const chartData = { x: index, y: duration };
+        if (topic === 'code') updateCodeGraph(chartData);
+        else if (topic === 'view') updateViewGraph(chartData);
+
+        if (
+          autoProfiling !== null &&
+          index >= env.profilingMessages &&
+          topic === 'view'
+        ) {
+          autoProfiling.samples.push(benchmarks);
+          localStorage.setItem('profiling', JSON.stringify(autoProfiling));
+          const samples = autoProfiling.samples.length;
+          autoProfiling = null;
+          if (samples >= env.profilingSamples) {
+            alert('Profiling finished');
+          } else window.location.reload();
+        }
+      }
+      return null;
+    } else return originalConsoleLog(message, ...optionalParams);
+  };
+
+  return { getBenchmarks: () => benchmarks };
+};
+
+export { Benchmark, Benchmarks, Profiling, profileApp };

--- a/yarn.lock
+++ b/yarn.lock
@@ -65,6 +65,13 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
+"@types/chart.js@^2.9.36":
+  version "2.9.36"
+  resolved "https://registry.yarnpkg.com/@types/chart.js/-/chart.js-2.9.36.tgz#8bdd3a625edaeef10367bc8a9e3239f077332de7"
+  integrity sha512-lkG9C6O5TqKyW3JDWMfCedVUATH4AeQCo8Q/vflT/0VDj6KMcba+jr1wLe+IXQ+F9mVWn80DVsDnt6cPuGutIg==
+  dependencies:
+    moment "^2.10.2"
+
 "@types/elm@^0.19.1":
   version "0.19.1"
   resolved "https://registry.yarnpkg.com/@types/elm/-/elm-0.19.1.tgz#a021a91739ce7c117b83c04726b0ca8abe7090fb"
@@ -254,6 +261,11 @@ chalk@^4.0.0, chalk@^4.1.0:
   dependencies:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
+
+chart.js@^3.7.1:
+  version "3.7.1"
+  resolved "https://registry.yarnpkg.com/chart.js/-/chart.js-3.7.1.tgz#0516f690c6a8680c6c707e31a4c1807a6f400ada"
+  integrity sha512-8knRegQLFnPQAheZV8MjxIXc5gQEfDFD897BJgv/klO/vtIyFFmgMXrNfgrXpbTr/XbTturxRgxIXx/Y+ASJBA==
 
 color-convert@^2.0.1:
   version "2.0.1"
@@ -895,6 +907,11 @@ mkdirp@^0.5.1:
   integrity sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==
   dependencies:
     minimist "^1.2.6"
+
+moment@^2.10.2:
+  version "2.29.2"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.2.tgz#00910c60b20843bcba52d37d58c628b47b1f20e4"
+  integrity sha512-UgzG4rvxYpN15jgCmVJwac49h9ly9NurikMWGPdVxm8GZD6XjkKPxDTjQQ43gtGgnV3X0cAyWDdP2Wexoquifg==
 
 ms@2.1.2:
   version "2.1.2"


### PR DESCRIPTION
#### :thinking: What?

- Allow us to see in charts how much time each init/update/view takes;
- Allow us to automatically profile N interactions of N messages storing them in the local storage.

![Cool charts](https://user-images.githubusercontent.com/1368952/162021997-0c375f8c-acee-428d-b130-89e49f76e5df.png)


#### :man_shrugging: Why?

- Something smells bad in my code.

#### :pushpin: Jira Issue

[LMO-2043](https://paacklogistics.atlassian.net/browse/LMO-2043).

#### :no_good: Blocked by

Nothing.

#### :clipboard: Pending

- [ ] Bump version.

### :fire: Extra

- This is a breaking change, to update you'll need to apply this modification:
```diff
diff --git a/src/Main/View.elm b/src/Main/View.elm
index f484c42..2a620a5 100644
--- a/src/Main/View.elm
+++ b/src/Main/View.elm
@@ -1,6 +1,5 @@
 module Main.View exposing (view)
 
-import Browser
 import Main.Model exposing (Model, authConfig)
 import Main.Msg as Msg exposing (Msg)
 import Main.Pages as Pages exposing (PageModel(..))
@@ -18,7 +17,7 @@ import UI.Link as Link
 import Views.Vectors as Vectors
 
 
-view : Model -> Browser.Document Msg
+view : Model -> Nav.Document PageModel Msg
 view model =
     let
         localeTerms =
@@ -36,7 +35,6 @@ view model =
             ]
         |> Nav.withMenuLogo localeTerms.logoHint Vectors.paackLogoGray
         |> Nav.withSidebarStyle Nav.sidebarNonPersistent
-        |> Nav.toBrowserDocument model.appConfig.renderConfig model.page
 
 
 menuPages : Model -> List Nav.MenuPage
```

- I also recommend migrating `Main.elm` and `tests/ProgramTest/${APP}.elm` to use the new `Paack.Program` structure:
```diff
diff --git a/src/Main.elm b/src/Main.elm
index b346abb..a43fa2e 100644
--- a/src/Main.elm
+++ b/src/Main.elm
@@ -1,20 +1,14 @@
 module Main exposing (main)
 
-import Browser
-import Main.Model exposing (Flags)
-import Main.Msg as Msg exposing (Msg)
-import Main.Subscriptions as Subscriptions
-import Main.View as View
-import Paack.Effects.MainHelper exposing (PerformerModel, performedInit, performedUpdate)
+import Main.Msg as Msg
+import Paack.Program as Paack
 
 
-main : Platform.Program Flags PerformerModel Msg
+main : Paack.Program
 main =
-    Browser.application
-        { init = performedInit
-        , view = .appModel >> View.view
-        , update = performedUpdate
-        , onUrlRequest = Msg.UrlRequested
+    Paack.browserApplication
+        { onUrlRequest = Msg.UrlRequested
         , onUrlChange = Msg.UrlChanged
-        , subscriptions = .appModel >> Subscriptions.subscriptions
+        , getRenderConfig = .appConfig >> .renderConfig
+        , getPage = .page
         }
diff --git a/tests/ProgramTest/LMO.elm b/tests/ProgramTest/LMO.elm
index dacc077..d246e7b 100644
--- a/tests/ProgramTest/LMO.elm
+++ b/tests/ProgramTest/LMO.elm
@@ -1,13 +1,12 @@
 module ProgramTest.LMO exposing (start)
 
 import Json.Encode as Encode
-import Main.Model as Model exposing (Flags, Model)
+import Main.Model exposing (Flags, Model)
 import Main.Msg as Msg exposing (Msg)
-import Main.Update exposing (update)
-import Main.View exposing (view)
 import Paack.Effects exposing (Effects)
 import Paack.Effects.Simulator exposing (simulator)
-import ProgramTest exposing (ProgramDefinition, ProgramTest)
+import Paack.ProgramTest as Paack exposing (ProgramDefinition)
+import ProgramTest exposing (ProgramTest)
 import ProgramTest.Helpers as ProgramTest
 
 
@@ -38,14 +37,13 @@ mockFlags =
     }
 
 
-programDefinition : ProgramDefinition Flags Model Msg (Effects Msg)
+programDefinition : ProgramDefinition
 programDefinition =
-    ProgramTest.createApplication
-        { init = Model.init
-        , view = view
-        , update = update
-        , onUrlRequest = Msg.UrlRequested
+    Paack.createApplication
+        { onUrlRequest = Msg.UrlRequested
         , onUrlChange = Msg.UrlChanged
+        , getRenderConfig = .appConfig >> .renderConfig
+        , getPage = .page
         }
 
 
```
