### PR TITLE
Drop duplicated Either

### DIFF
--- a/elm/Paack/Basics.elm
+++ b/elm/Paack/Basics.elm
@@ -1,11 +1,6 @@
 module Paack.Basics exposing (..)
 
 
-type Either a b
-    = Left a
-    | Right b
-
-
 range : (Int -> a) -> Int -> Int -> Int -> List ( a, a )
 range mapper interval start end =
     if interval <= 0 then


### PR DESCRIPTION
#### :thinking: What?

- Drop `Paack.Basics.Either`.

#### :man_shrugging: Why?

- It was already implemented in `Paack.Either.Either`

#### :pushpin: Jira Issue

Not tracked

#### :no_good: Blocked by

Not blocked

### :fire: Extra

I won't do a release for this...